### PR TITLE
syncing up with voxer's internal lb_pool

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -199,6 +199,12 @@ Pool.prototype.post = function (options, data, callback) {
     return this.request(options, data, callback);
 };
 
+Pool.prototype.head = function (options, data, callback) {
+    options = this.init_req_options(options);
+    options.method = "HEAD";
+    return this.request(options, data, callback);
+};
+
 Pool.prototype.del = function (options, callback) {
     options = this.init_req_options(options);
     options.method = "DELETE";

--- a/pool_request_set.js
+++ b/pool_request_set.js
@@ -54,7 +54,12 @@ PoolRequestSet.prototype.handle_response = function (err, response, body) {
             this.aborts++;
         }
 
-        if (this.attempts_remaining > 0 && err.reason !== "full" && err.reason !== "unhealthy" && this.hangups < this.max_hangups && this.aborts < this.max_aborts) {
+        if (this.attempts_remaining > 0 &&
+          err.reason !== "full" &&
+          err.reason !== "unhealthy" &&
+          err.message.indexOf("timed out") === -1 &&
+          this.hangups < this.max_hangups &&
+          this.aborts < this.max_aborts) {
             this.pool.on_retry(err);
             if (delay > 0) {
                 setTimeout(this.do_request.bind(this), delay);

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -244,4 +244,22 @@ describe("Pool request()", function () {
         });
         next();
     });
+
+    it("dont retry timeout", function (done) {
+        var reqs = 0;
+        var server = http.createServer(function (req, res) { reqs++; }).listen(6960);
+        var pool = new Pool(http, ["127.0.0.1:6960"], { ping: "/ping", timeout: 20 });
+        pool.on("retrying", function () { throw new Error(); });
+        pool.get({
+            path: "/foo",
+            retry_delay: 1
+        }, function (err, res, body) {
+            assert(err);
+            assert(!res);
+            assert(!body);
+            assert.equal(reqs, 1);
+            server.close();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
These are the changes I picked out of our internal Voxer lb_pool repo.  Syncing these changes will allow us to use the lb_pool from npm.  At some point we decided retrying timeouts was not a good thing.