### PR TITLE
Free body chunks after concating them

### DIFF
--- a/pool_endpoint_request.js
+++ b/pool_endpoint_request.js
@@ -143,6 +143,7 @@ PoolEndpointRequest.prototype.on_end = function () {
         } else {
             body = body_buf;
         }
+        this.body_chunks.length = 0;
     }
 
     var delay = this.options.retry_filter(this.options, this.response, body);


### PR DESCRIPTION
Frees the body chunks after they're cat'd together. Especially if they're `toString()`ed there's no reason to keep these around, they just take up unnecessary space.

r @mranney @anandsuresh