### PR TITLE
Add an explicit abort listener.

### DIFF
--- a/pool_endpoint_request.js
+++ b/pool_endpoint_request.js
@@ -56,6 +56,9 @@ PoolEndpointRequest.prototype.start = function () {
     this.out_request.on("response", function (response) { self.on_response(response); });
     this.out_request.on("error", function (err) { self.on_error(err); });
     this.out_request.on("drain", function () { self.on_drain(); });
+    this.out_request.on("abort", function onAbort(err) {
+        self.on_error(new Error('lb_pool: request aborted'));
+    });
 
     var data = this.options.data;
     if (!data && this.options.end === false) {

--- a/test/endpoint_test.js
+++ b/test/endpoint_test.js
@@ -118,8 +118,9 @@ describe("PoolEndpoint", function () {
 
                 setTimeout(function () {
                     s.close();
+
                     assert.equal(error.reason, "timed_out");
-                    assert.equal(/response timed out$/.test(error.message), true);
+                    assert.equal(/timed out$/.test(error.message), true);
                     done();
                 }, 60);
             });


### PR DESCRIPTION
This explicit abort listener will improve handling of errors
and time outs for this OutRequest instance in case the only
"event" that fires is the abort event.

Otherwise we may end up with a "callback not called" situation.

r: @Matt-Esch @rf

cc: @anandsuresh , applying your fix as well in a seperate PR.