### PR TITLE
Add Math.floor to ensure that we overwrite indexes.

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -358,7 +358,7 @@ Pool.prototype.add_endpoint = function add_endpoint(host_port) {
     // if using maxSize, probabilistically add the new host port to the
     // active pool endpoints
     if (maxSizeIsRelevant) {
-        var r = Math.random() * this.all_hostports.length;
+        var r = Math.floor(Math.random() * this.all_hostports.length);
         // note: the + 1 is a significant bias correction for adding then removing
         if (r < this.max_pool_size + 1) {
             this.add_pool_endpoint(host_port);

--- a/pool.js
+++ b/pool.js
@@ -72,7 +72,7 @@ function Pool(http, endpoints, options) {
                 selectedEndpoints[j] = endpoints[j];
             } else {
                 // random replacement with decreasing probablity
-                var r = Math.random() * (j + 1);
+                var r = Math.floor(Math.random() * (j + 1));
                 if (r < this.max_pool_size) {
                     selectedEndpoints[r] = endpoints[j];
                 }

--- a/test/pool_test.js
+++ b/test/pool_test.js
@@ -82,6 +82,46 @@ describe("Pool", function () {
         assert.equal(p.length, 2);
     });
 
+    it("selecting endpoints from max_pool_size should be random", function () {
+        var endpoints = [
+            "127.0.0.1:8080",
+            "127.0.0.1:8081",
+            "127.0.0.1:8082",
+            "127.0.0.1:8083",
+            "127.0.0.1:8084",
+            "127.0.0.1:8085",
+            "127.0.0.1:8086"
+        ];
+
+        var pools = [
+            new Pool(http, endpoints, {max_pool_size: 2}),
+            new Pool(http, endpoints, {max_pool_size: 2}),
+            new Pool(http, endpoints, {max_pool_size: 2}),
+            new Pool(http, endpoints, {max_pool_size: 2}),
+            new Pool(http, endpoints, {max_pool_size: 2}),
+            new Pool(http, endpoints, {max_pool_size: 2}),
+            new Pool(http, endpoints, {max_pool_size: 2})
+        ];
+
+        var seenEndpoints = {};
+        for (var i = 0; i < pools.length; i++) {
+            var p = pools[i];
+            var endpointsByName = Object.keys(p.endpoints_by_name);
+            for (var j = 0; j < endpointsByName.length; j++) {
+                var hostPort = endpointsByName[j];
+                if (!seenEndpoints[hostPort]) {
+                    seenEndpoints[hostPort] = 1;
+                } else {
+                    seenEndpoints[hostPort]++;
+                }
+            }
+        }
+
+        // Should see at least 75% of endpoints picked.
+        var numberOfEndpoints = Object.keys(seenEndpoints).length;
+        assert.ok(numberOfEndpoints >= 5)
+    });
+
     it("throws an Error when options.max_pool_size is invalid", function () {
         assert.throws(function () {
             return new Pool({}, ["127.0.0.1:8080"], {max_pool_size: -1});


### PR DESCRIPTION
There is a bug here that Math.floor() was not being called.
The code was overwriting the previous 100 instances but instead
of overwriting them they were inserting floating points keys into
the array as keys turning the array into a dictionary.

When we add endpoints to lb_pool, we loop over the array and just
add the first 100 items, which are the original ones and not the
looping over the dictionary keys we inserted.

r: @Matt-Esch @jakelarkn